### PR TITLE
[fix] python version 3.11로 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13
+FROM python:3.11-slim
 
 WORKDIR /app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Jueuunn7",email = "wndmsrla1234@gmail.com"}
 ]
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = "=3.11"
 dependencies = [
     "django (>=5.2,<6.0)",
     "djangorestframework (>=3.16.0,<4.0.0)",


### PR DESCRIPTION
## 개요
3.13에서 지원하지 않는 라이브러리가 있어서 11로 다운그레이드 했습니다.

## 변경사항
- dockerfile python image change
- poetry python version update