### PR TITLE
[fix] 파이썬 버전 제한 수정

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Jueuunn7",email = "wndmsrla1234@gmail.com"}
 ]
 readme = "README.md"
-requires-python = "=3.11"
+requires-python = "^3.11"
 dependencies = [
     "django (>=5.2,<6.0)",
     "djangorestframework (>=3.16.0,<4.0.0)",


### PR DESCRIPTION
## 개요
=3.11이여서 발생하는 도커 빌드시 문제를 파이썬 버전 완화를 통해 해결했습니다.

## 변경사항
- python version